### PR TITLE
Fix prefer header handling, and fix crash with big calendars. Fix  #53.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "jsDAV": "cozy/jsDAV#c43a719d1e",
+    "cozy-realtime-adapter": "0.11.3",
     "async": "0.2.10",
     "moment": "2.5.1",
     "lazy": "1.0.11",

--- a/server.coffee
+++ b/server.coffee
@@ -11,6 +11,12 @@ application = module.exports = (callback) ->
 
     require('./server/models/webdavaccount').first ->
         americano.start options, (app, server) ->
+            User = require './server/models/user'
+            Realtimer = require 'cozy-realtime-adapter'
+            realtime = Realtimer server : server, ['event.*']
+            realtime.on 'user.*', -> User.updateUser()
+            User.updateUser() # initialize User attributes.
+
             initialize ->
                 callback app, server if callback?
 

--- a/server/models/user.coffee
+++ b/server/models/user.coffee
@@ -7,3 +7,12 @@ User.getTimezone = (callback) ->
     User.all (err, users) ->
         return callback err if err
         callback null, users?[0]?.timezone or "Europe/Paris"
+
+User.updateUser = (callback) ->
+    User.getTimezone (err, timezone) ->
+        if err
+            console.log err
+            User.timezone = 'Europe/Paris'
+        else
+            User.timezone = timezone or "Europe/Paris"
+        callback?()


### PR DESCRIPTION
Update jsDAV dependency to handle prefer headers.
Add cache on caldav.coffee::getCalendarsUser to fix timeouts crash with big calendars.
Cache User.timezone too.
