### PR TITLE
Update cozy-jsdav-fork → 0.3.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "async": "0.2.10",
     "axon": "1.0.0",
     "cozy-ical": "1.1.19",
-    "cozy-jsdav-fork": "0.3.15",
+    "cozy-jsdav-fork": "0.3.16",
     "cozy-realtime-adapter": "0.11.3",
     "cozy-vcard": "0.2.17",
     "cozydb": "0.1.10",


### PR DESCRIPTION
We forgot to apply the fix for handling of CalDAV Unknown method